### PR TITLE
Update step size on Transcendent Power input

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
           
           <div class="flex">
              <label><a onclick="void(0)" onmouseover="nhpup.popup('Transcendent Power (TP) is found on the Outsiders tab.  It is 0 if you have not yet transcended.');"><label>Transcendent Power <div class="sublabel">(1.35% = 1.35)</div></a>:</label>
-            <input class="calcinput" type="number" name="idle_tp" id="idle_tp" value="0">
+            <input class="calcinput" type="number" name="idle_tp" id="idle_tp" value="0" step="0.01">
           </div>
 
           <div class="flex">


### PR DESCRIPTION
In certain browsers (I tested in Firefox), the TP input box will gain a red border if a decimal is entered.  This is because the default step size for a number input is 1, so Firefox thinks any decimal is an invalid input.  This can be fixed by specifying the step size to .01, which also means that the arrows in the box can be used for fine-grain adjustment.

As far as I know this is an entirely cosmetic change - the calculator will work either way.